### PR TITLE
Database Release: v2.1

### DIFF
--- a/London.sql.zip
+++ b/London.sql.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:09ba15dc6361465b6ada79b292a755fc9eea0022720ba071e2e98623260b40ad
-size 27008895
+oid sha256:a271b67146f6bf2c8a884b037cb21d67e6530c55826eb49cc4db04c1a94dcabd
+size 27021125

--- a/LondonStageFull.csv.zip
+++ b/LondonStageFull.csv.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:86d8cfaf7161acf3d5ffcceefeb6dd2608ffeff410a92880d77cd85e51d55a88
-size 45639035
+oid sha256:ff5f384b1ef8f241e80fe29ba742fccca771af2712efde4541d286d624ad5131
+size 45635869

--- a/LondonStageFull.json.zip
+++ b/LondonStageFull.json.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ce8149602a6119de79ac0f8aae39ec047d8bb8ef24bef14bce79b155361823b
-size 32468302
+oid sha256:1094bc5fc01884d895a79afedbd06468319fb1f10e1bf7b25f41d62b3085c075
+size 32475542

--- a/LondonStageFull.xml.zip
+++ b/LondonStageFull.xml.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2bf37cb612178cfeb1ef99fbb441b55945f8c5d80ff984388a2fff917a5d478f
-size 36565365
+oid sha256:33b2e2b5b784db3c4f2777d454ec3850063a541e8b206b184b7fb88ecf3198dd
+size 36564717

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ For reproducibility, these scripts document
 the SQL commands executed to increment or "upgrade" the database from 1.0 to 1.1.
 They are applied to **v1.0** of the database in ascending order.
 
-#### v2.0
-Because the corrections made to the database between versions 1.1 and 2.0 were so substantial, impacting thousands of rows, we have chosen not to provide SQL scripts to upgrade 1.1 to 2.0. 
+Because the corrections made to the database after versions 1.1 were so substantial, impacting thousands of rows, we have chosen not to provide SQL scripts to upgrade 1.1 to 2.0, or from
+2.0 to 3.0 
 
 #### v1.1
 * `scripts/01_constraint_prep.sql`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ the SQL commands executed to increment or "upgrade" the database from 1.0 to 1.1
 They are applied to **v1.0** of the database in ascending order.
 
 Because the corrections made to the database after versions 1.1 were so substantial, impacting thousands of rows, we have chosen not to provide SQL scripts to upgrade 1.1 to 2.0, or from
-2.0 to 3.0 
+2.0 to 2.1. 
 
 #### v1.1
 * `scripts/01_constraint_prep.sql`

--- a/docs/data-dictionary.md
+++ b/docs/data-dictionary.md
@@ -17,7 +17,9 @@ Stores information about authors and their dates of flourishing.
 | Column| Type | Constraints | Description | Example |
 |------------------|-----------|-------------------|-------------|------------|
 | AuthId   | int(6) | PRIMARY KEY, NOT NULL  | unique author identifier | `1` |
-| AuthName  | varchar(50)  | NOT NULL  | name in "First Last" form  | `John Suckling`    |
+| AuthName  | varchar(50)  | NOT NULL  | name in "First Last" form  | `John Suckling` |
+| WikidataId | varchar(20) | NULL | Wikidata identifier | `Q2339246` |
+| URL | varchar(5) | NULL | Wikidata URL | `https://www.wikidata.org/wiki/Q2339246` | 
 | StartDate | varchar(20)  | NOT NULL  | birth date or earliest known flourish date | `1609` |
 | StartType  | varchar(15)  | NOT NULL  | type of start date, flourishing, baptism, birth | `baptism` |
 | EndDate | varchar(20)  | NOT NULL | death date or earliest known flourish date  |`1641?` |
@@ -127,7 +129,7 @@ Stores matches between LSDB works and TCP files, with one match per row. Researc
 |-----------------------|---------------|-------------|-------------|----------------|
 | TCPId | varchar(11) | NOT NULL, PRIMARY KEY (composite) | TCP project identifier  | `K044879.000` |
 | WorkId  | int(4)  | NOT NULL, PRIMARY KEY (composite) | LSDB WorkId | `13` |
-| MatchType | varchar(10) | NULL  | Type of match, `collection` indicates a match to a part of a collection  | `match` |
+| MatchType | varchar(10) | NOT NULL | Type of match, `collection` indicates a match to a part of a collection  | `match` |
 
 
 ## TCP

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,12 @@
 # London Stage Database: Release Notes
 
+## 2.1
+
+Released June _, 2026.
+
+A major release that adds WorkIds to thousands of performances in the
+Performance table and significantly improves the 
+
 ## 2.0
 
 Released October 9th, 2025.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -27,7 +27,7 @@ PerformanceTitle and PerfTitleClean fields of 648 performances.
 ### Contributors
 * Mattie Burkert
 * Erin Winter
-* Quyn-Tran Le
+* Quynh-Tran Le
 * Ceilidh McCallum
 * Rose Ruhnke
 * Chelsea Phillips

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,7 +2,7 @@
 
 ## 2.1
 
-Released June 2, 2026.
+Released June 1, 2026.
 
 A minor release that adds WorkIds to thousands of performances in the
 Performance table, significantly improving the accuracy of the 
@@ -11,9 +11,11 @@ the London Stage Database and other theatrical datasets.
 
 ### Enhancements
 * Adds WorkIds to 4184 performances in the Performances table.
-* Adds the WikidataId and URL fields to the Author table.
+* Adds the WikidataId and URL fields to the Author table in preparation for a future 
+new feature.
 * Amends 43 authorship attributions in the WorkAuthMaster table.
-* Corrects spacing, transcription, and spelling errors in the titles of 648 performances in Performances.
+* Corrects spacing, transcription, and spelling errors in the 
+PerformanceTitle and PerfTitleClean fields of 648 performances.
 
 ### Bug fixes
 * Removes extra white space from 3446 rows in the Cast table.
@@ -21,6 +23,14 @@ the London Stage Database and other theatrical datasets.
 * Adds missing MatchType values to 33 rows in WorksTCP.
 * Adds 9 variants to the AuthorVariant table.
 * Removes 3 disqualified entries (not theatrical works) from the TCP table.
+
+### Contributors
+* Mattie Burkert
+* Erin Winter
+* Quyn-Tran Le
+* Ceilidh McCallum
+* Rose Ruhnke
+* Chelsea Phillips
 
 ## 2.0
 
@@ -52,6 +62,11 @@ WorksVariant, and Performances tables.
 * Adds a new data dictionary to the `docs/` folder of this repository.
 * Updates `docs/schema.png` to reflect new table structure.
 
+### Contributors
+* Michele Pflug
+* Mattie Burkert
+* Erin Winter
+
 ## 1.1 
 
 Released April 4th, 2025.
@@ -66,3 +81,7 @@ The first release of the database after active development resumed in 2025. This
 * Adds foreign key constraints between relational database tables. 
     - For example, it is no longer possible for Events to be held at a Theatre that does not exist in the Theatre table.
 * These constraints will prevent the addition of values to one table that conflict with information in a corresponding table, a necessary safeguard as we expand the database.
+
+### Contributors
+* Erin Winter
+* Mattie Burkert

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,10 +2,25 @@
 
 ## 2.1
 
-Released June _, 2026.
+Released June 2, 2026.
 
-A major release that adds WorkIds to thousands of performances in the
-Performance table and significantly improves the 
+A minor release that adds WorkIds to thousands of performances in the
+Performance table, significantly improving the accuracy of the 
+Related Works algorithm. Improves interoperability among
+the London Stage Database and other theatrical datasets.
+
+### Enhancements
+* Adds WorkIds to 4184 performances in the Performances table.
+* Adds the WikidataId and URL fields to the Author table.
+* Amends 43 authorship attributions in the WorkAuthMaster table.
+* Corrects spacing, transcription, and spelling errors in the titles of 648 performances in Performances.
+
+### Bug fixes
+* Removes extra white space from 3446 rows in the Cast table.
+* Corrects titles related to Handel's Messiah in Works.
+* Adds missing MatchType values to 33 rows in WorksTCP.
+* Adds 9 variants to the AuthorVariant table.
+* Removes 3 disqualified entries (not theatrical works) from the TCP table.
 
 ## 2.0
 


### PR DESCRIPTION
A minor release that adds WorkIds to thousands of performances in the Performance table, significantly improving the accuracy of the Related Works algorithm. Improves interoperability among the London Stage Database and other theatrical datasets.

* Updates SQL, CSV, JSON, and XML versions of the database the latest zip files
* Updates data dictionary
* Adds contributor fields to the release notes
* Updates README